### PR TITLE
Decimal precision not as localcontext-arg

### DIFF
--- a/jsonsum/jsonsum.py
+++ b/jsonsum/jsonsum.py
@@ -56,7 +56,8 @@ def jsonsum_crc32(j, sum=0):
 def normalize_number(n):
     if n == 0:
         return '0e0'
-    with decimal.localcontext(prec=decimal.MAX_PREC) as ctx:
+    with decimal.localcontext() as ctx:
+        ctx.prec = decimal.MAX_PREC
         d = decimal.Decimal(n).as_tuple()
         digits = ''.join(str(digit) for digit in d.digits) # n is now a string of digits, without decimal point but may have trailing zeros
         stripped_digits = digits.rstrip('0')


### PR DESCRIPTION
Refer refer https://bugs.python.org/issue47135
Just setting it on the ctx object seems to work fine as well, tests pass, manual tests indicate no change in sums.

With the previous version, I encountered the following issue when running pytest

```
pytest                                                                                                                                        :(
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.6, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/tbergmueller/DEV/benchmark/jsonsum-py
collected 26 items                                                                                                                                                                                                

jsonsum_test.py FF..........FFFFFFFFFF.F..                                                                                                                                                                  [100%]

==================================================================================================== FAILURES =====================================================================================================
__________________________________________________________________ test_testdata[Different key order gives the same checksum-jsons0-1308407541] ___________________________________________________________________

name = 'Different key order gives the same checksum', jsons = ['{"hi":1,"ho":2}', '{"ho":2,"hi":1}'], expected = 1308407541

    @pytest.mark.parametrize(['name', 'jsons', 'expected'], testdata)
    def test_testdata(name, jsons, expected):
        for j in jsons:
            j = json.loads(j)
>           assert jsonsum_crc32(j) == expected

jsonsum_test.py:14: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
jsonsum/jsonsum.py:34: in jsonsum_crc32
    item_sum = jsonsum_crc32(v, item_sum)
jsonsum/jsonsum.py:52: in jsonsum_crc32
    return crc32(normalize_number(j).encode(), sum)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

n = 1

    def normalize_number(n):
        if n == 0:
            return '0e0'
>       with decimal.localcontext(prec = decimal.MAX_PREC) as ctx:
E       TypeError: 'prec' is an invalid keyword argument for this function

jsonsum/jsonsum.py:59: TypeError

```
Environment:
- Ubuntu 22.04
- Python 3.10.6

pip list:
```
Package        Version
-------------- -------
exceptiongroup 1.1.1
iniconfig      2.0.0
packaging      23.1
pip            22.0.2
pluggy         1.2.0
pytest         7.4.0
setuptools     59.6.0
tomli          2.0.1
```

